### PR TITLE
ENG-7233: Set proper partitions and account ID to IAM policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ No modules.
 | [aws_secretsmanager_secret_version.cyral-sidecar-secret-version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_security_group.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_ami.amazon_linux_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_arn.cw_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
 | [aws_availability_zones.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.init_script_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sidecar](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |

--- a/iam_resources.tf
+++ b/iam_resources.tf
@@ -1,4 +1,10 @@
-data "aws_caller_identity" "current" {}
+# Gets the ARN from a resource that is deployed by this module in order to
+# get the proper partition, region and account number for the aws account
+# where the resources are actually deployed. This prevents issues with
+# deployment pipelines that runs on AWS and deploys to different accounts.
+data "aws_arn" "cw_lg" {
+  arn = aws_cloudwatch_log_group.cyral-sidecar-lg.arn
+}
 
 data "aws_iam_policy_document" "init_script_policy" {
   # Policy doc to allow sidecar to function inside an ASG
@@ -29,8 +35,8 @@ data "aws_iam_policy_document" "init_script_policy" {
       "secretsmanager:GetSecretValue"
     ]
     resources = compact([
-      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:/cyral/*",
-      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${var.secrets_location}*"
+      "arn:${data.aws_arn.cw_lg.partition}:secretsmanager:${data.aws_arn.cw_lg.region}:${data.aws_arn.cw_lg.account}:secret:/cyral/*",
+      "arn:${data.aws_arn.cw_lg.partition}:secretsmanager:${data.aws_arn.cw_lg.region}:${data.aws_arn.cw_lg.account}:secret:${var.secrets_location}*"
     ])
   }
 }


### PR DESCRIPTION
Get partition, region and account information from deployed resources. This will enable deployments in GovCloud and also prevent errors in deployment pipelines running on AWS that deploys to different AWS accounts. The later does not work as previous version of the code would get the account ID from the caller identity. In this sense, if you run `terraform apply` in account `A` to deploy to account `B`, then the previous code would create IAM permissions referencing account `A`, not account `B` where the resources were actually deployed.