### PR TITLE
ENG-7488: Reduce sidecar default instance size

### DIFF
--- a/variables_aws.tf
+++ b/variables_aws.tf
@@ -90,7 +90,7 @@ EOF
 variable "volume_size" {
   description = "Size of the sidecar disk"
   type        = number
-  default     = 30
+  default     = 15
 }
 
 variable "ssh_inbound_cidr" {


### PR DESCRIPTION
# Description of the change
>
[ENG-7488](https://cyralinc.atlassian.net/browse/ENG-7488): Reduce sidecar default instance size

Changed parameters:

-  Default volume size for sidecar instances (from 30GB to 15GB);
