### PR TITLE
ENG-8228: Add reduce_security_group_rules_count variable to avoid cartesian product in security group rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ```hcl
 module "cyral_sidecar" {
     source  = "cyralinc/sidecar-aws/cyral"  
-    version = "2.5.4" # terraform module version
+    version = "2.6.4" # terraform module version
 
     sidecar_version = ""
     sidecar_id      = ""
@@ -140,6 +140,7 @@ No modules.
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets to add sidecar to (list of string) | `list(string)` | n/a | yes |
 | <a name="input_sumologic_host"></a> [sumologic\_host](#input\_sumologic\_host) | Sumologic host | `string` | `""` | no |
 | <a name="input_sumologic_uri"></a> [sumologic\_uri](#input\_sumologic\_uri) | Sumologic uri | `string` | `""` | no |
+| <a name="input_use_inbound_port_range"></a> [use\_inbound\_port\_range](#input\_use\_inbound\_port\_range) | If set to true, a port range (between the smallest and the biggest sidecar port) will be used to configure the inbound rules for the sidecar security group. This can be useful if you need to use multiple sidecar ports and different CIDRs for DB inbound (db\_inbound\_cidr) since it will significantly reduce the number of inbound rules. On the other hand, all the ports between min(sidecar\_ports) and max(sidecar\_ports) will be open in the security group. | `bool` | `false` | no |
 | <a name="input_volume_size"></a> [volume\_size](#input\_volume\_size) | Size of the sidecar disk | `number` | `15` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | AWS VPC ID to deploy sidecar to | `string` | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ```hcl
 module "cyral_sidecar" {
     source  = "cyralinc/sidecar-aws/cyral"  
-    version = "2.6.4" # terraform module version
+    version = "2.6.0" # terraform module version
 
     sidecar_version = ""
     sidecar_id      = ""
@@ -140,7 +140,7 @@ No modules.
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets to add sidecar to (list of string) | `list(string)` | n/a | yes |
 | <a name="input_sumologic_host"></a> [sumologic\_host](#input\_sumologic\_host) | Sumologic host | `string` | `""` | no |
 | <a name="input_sumologic_uri"></a> [sumologic\_uri](#input\_sumologic\_uri) | Sumologic uri | `string` | `""` | no |
-| <a name="input_use_inbound_port_range"></a> [use\_inbound\_port\_range](#input\_use\_inbound\_port\_range) | If set to true, a port range (between the smallest and the biggest sidecar port) will be used to configure the inbound rules for the sidecar security group. This can be useful if you need to use multiple sidecar ports and different CIDRs for DB inbound (db\_inbound\_cidr) since it will significantly reduce the number of inbound rules. On the other hand, all the ports between min(sidecar\_ports) and max(sidecar\_ports) will be open in the security group. | `bool` | `false` | no |
+| <a name="input_reduce_security_group_rules_count"></a> [reduce\_security\_group\_rules\_count](#input\_reduce\_security\_group\_rules\_count) | If set to `false`, each port in `sidecar_ports` will be used individually for each CIDR in `db_inbound_cidr` to create inbound rules in the sidecar security group, resulting in a number of inbound rules that is equal to the number of `sidecar_ports` * `db_inbound_cidr`. If set to `true`, the entire sidecar port range from `min(sidecar_ports)` to `max(sidecar_ports)` will be used to configure each inbound rule for each CIDR in `db_inbound_cidr` for the sidecar security group. Setting it to `true` can be useful if you need to use multiple sequential sidecar ports and different CIDRs for DB inbound (`db_inbound_cidr`) since it will significantly reduce the number of inbound rules and avoid hitting AWS quotas. As a side effect, it will open all the ports between `min(sidecar_ports)` and `max(sidecar_ports)` in the security group created by this module. | `bool` | `false` | no |
 | <a name="input_volume_size"></a> [volume\_size](#input\_volume\_size) | Size of the sidecar disk | `number` | `15` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | AWS VPC ID to deploy sidecar to | `string` | n/a | yes |
 

--- a/ec2_resources.tf
+++ b/ec2_resources.tf
@@ -115,18 +115,18 @@ resource "aws_security_group" "instance" {
     security_groups = var.ssh_inbound_security_group
   }
 
-  # If use_inbound_port_range is true, it will create DB Inbound Rules per CIDR using
+  # If reduce_security_group_rules_count is true, it will create DB Inbound Rules per CIDR using
   # a port range (between the smallest and the biggest sidecar port). Otherwise, it will
   # create DB Inbound Rules per sidecar port and CIDR (Cartesian Product between Ports x CIDRs).
   # Notice that the ingress block accepts a list of CIDRs (cidr_blocks), which internally will
   # create one ingress rule per CIDR. This is an AWS limitation, which doesnt allow creating a
   # single ingress rule for a list of CIDRs.
   dynamic "ingress" {
-    for_each = var.use_inbound_port_range ? [1] : var.sidecar_ports
+    for_each = var.reduce_security_group_rules_count ? [1] : var.sidecar_ports
     content {
       description     = "DB"
-      from_port       = var.use_inbound_port_range ? min(var.sidecar_ports...) : ingress.value
-      to_port         = var.use_inbound_port_range ? max(var.sidecar_ports...) : ingress.value
+      from_port       = var.reduce_security_group_rules_count ? min(var.sidecar_ports...) : ingress.value
+      to_port         = var.reduce_security_group_rules_count ? max(var.sidecar_ports...) : ingress.value
       protocol        = "tcp"
       cidr_blocks     = var.db_inbound_cidr
       security_groups = var.db_inbound_security_group

--- a/variables_aws.tf
+++ b/variables_aws.tf
@@ -109,8 +109,8 @@ variable "db_inbound_cidr" {
   type        = list(string)
 }
 
-variable "use_inbound_port_range" {
-  description = "If set to true, a port range (between the smallest and the biggest sidecar port) will be used to configure the inbound rules for the sidecar security group. This can be useful if you need to use multiple sidecar ports and different CIDRs for DB inbound (db_inbound_cidr) since it will significantly reduce the number of inbound rules. On the other hand, all the ports between min(sidecar_ports) and max(sidecar_ports) will be open in the security group."
+variable "reduce_security_group_rules_count" {
+  description = "If set to `false`, each port in `sidecar_ports` will be used individually for each CIDR in `db_inbound_cidr` to create inbound rules in the sidecar security group, resulting in a number of inbound rules that is equal to the number of `sidecar_ports` * `db_inbound_cidr`. If set to `true`, the entire sidecar port range from `min(sidecar_ports)` to `max(sidecar_ports)` will be used to configure each inbound rule for each CIDR in `db_inbound_cidr` for the sidecar security group. Setting it to `true` can be useful if you need to use multiple sequential sidecar ports and different CIDRs for DB inbound (`db_inbound_cidr`) since it will significantly reduce the number of inbound rules and avoid hitting AWS quotas. As a side effect, it will open all the ports between `min(sidecar_ports)` and `max(sidecar_ports)` in the security group created by this module."
   type = bool
   default = false
 }

--- a/variables_aws.tf
+++ b/variables_aws.tf
@@ -109,6 +109,12 @@ variable "db_inbound_cidr" {
   type        = list(string)
 }
 
+variable "use_inbound_port_range" {
+  description = "If set to true, a port range (between the smallest and the biggest sidecar port) will be used to configure the inbound rules for the sidecar security group. This can be useful if you need to use multiple sidecar ports and different CIDRs for DB inbound (db_inbound_cidr) since it will significantly reduce the number of inbound rules. On the other hand, all the ports between min(sidecar_ports) and max(sidecar_ports) will be open in the security group."
+  type = bool
+  default = false
+}
+
 variable "db_inbound_security_group" {
   description = "Pre-existing security group IDs allowed to connect to db in the EC2 host. Can't be combined with 'db_inbound_cidr'."
   type        = list(string)


### PR DESCRIPTION
See [ENG-8228](https://cyralinc.atlassian.net/browse/ENG-8228): Create sidecar template feature to avoid cartesian product in security group rules.

Related PR: [sidecar-templates#896](https://github.com/cyralinc/sidecar-templates/pull/896)