### PR TITLE
ENG-7468: Support for cross-account deployments for ca-signed certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Terraform
+.terraform*
+terraform.tfstate*
+*.tfvars
+
+# Emacs
+*~
+*#

--- a/README.md
+++ b/README.md
@@ -57,8 +57,11 @@ No modules.
 | [aws_autoscaling_group.cyral-sidecar-asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_cloudwatch_log_group.cyral-sidecar-lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_instance_profile.sidecar_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_policy.casigned_certificate_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.init_script_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.casigned_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.sidecar_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.casigned_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.init_script_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.user_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_launch_configuration.cyral-sidecar-lc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) | resource |
@@ -66,12 +69,16 @@ No modules.
 | [aws_lb_listener.cyral-sidecar-lb-ls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_target_group.cyral-sidecar-tg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_route53_record.cyral-sidecar-dns-record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_secretsmanager_secret.casigned_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.cyral-sidecar-secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.self_signed_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.cyral-sidecar-secret-version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_security_group.instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_ami.amazon_linux_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_arn.cw_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
 | [aws_availability_zones.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_iam_policy_document.casigned_certificate_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.casigned_certificate_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.init_script_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sidecar](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
@@ -122,8 +129,10 @@ No modules.
 | <a name="input_mongodb_port_alloc_range_low"></a> [mongodb\_port\_alloc\_range\_low](#input\_mongodb\_port\_alloc\_range\_low) | Initial value for MongoDB port allocation range. The consecutive ports in the<br>range `mongodb_port_alloc_range_low:mongodb_port_alloc_range_high` will be used<br>for mongodb cluster monitoring. All the ports in this range must be listed in<br>`sidecar_ports`. | `number` | n/a | yes |
 | <a name="input_mysql_multiplexed_port"></a> [mysql\_multiplexed\_port](#input\_mysql\_multiplexed\_port) | Port that will be used by the sidecar to multiplex connections to MySQL | `number` | `0` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for names of created resources in AWS | `string` | n/a | yes |
+| <a name="input_reduce_security_group_rules_count"></a> [reduce\_security\_group\_rules\_count](#input\_reduce\_security\_group\_rules\_count) | If set to `false`, each port in `sidecar_ports` will be used individually for each CIDR in `db_inbound_cidr` to create inbound rules in the sidecar security group, resulting in a number of inbound rules that is equal to the number of `sidecar_ports` * `db_inbound_cidr`. If set to `true`, the entire sidecar port range from `min(sidecar_ports)` to `max(sidecar_ports)` will be used to configure each inbound rule for each CIDR in `db_inbound_cidr` for the sidecar security group. Setting it to `true` can be useful if you need to use multiple sequential sidecar ports and different CIDRs for DB inbound (`db_inbound_cidr`) since it will significantly reduce the number of inbound rules and avoid hitting AWS quotas. As a side effect, it will open all the ports between `min(sidecar_ports)` and `max(sidecar_ports)` in the security group created by this module. | `bool` | `false` | no |
 | <a name="input_repositories_supported"></a> [repositories\_supported](#input\_repositories\_supported) | List of all repositories that will be supported by the sidecar (lower case only) | `list(string)` | <pre>[<br>  "denodo",<br>  "dremio",<br>  "mongodb",<br>  "mysql",<br>  "oracle",<br>  "postgresql",<br>  "redshift",<br>  "rest",<br>  "snowflake",<br>  "sqlserver",<br>  "s3"<br>]</pre> | no |
 | <a name="input_secrets_location"></a> [secrets\_location](#input\_secrets\_location) | Location in AWS Secrets Manager to store client\_id, client\_secret and container\_registry\_key | `string` | n/a | yes |
+| <a name="input_sidecar_certficate_casigned_account_id"></a> [sidecar\_certficate\_casigned\_account\_id](#input\_sidecar\_certficate\_casigned\_account\_id) | (Optional) AWS Account ID where the certificate CA-signed stack will be deployed. | `string` | `""` | no |
 | <a name="input_sidecar_dns_hosted_zone_id"></a> [sidecar\_dns\_hosted\_zone\_id](#input\_sidecar\_dns\_hosted\_zone\_id) | (Optional) Route53 hosted zone ID for the corresponding 'sidecar\_dns\_name' provided | `string` | `""` | no |
 | <a name="input_sidecar_dns_name"></a> [sidecar\_dns\_name](#input\_sidecar\_dns\_name) | (Optional) Fully qualified domain name that will be automatically created/updated to reference the sidecar LB | `string` | `""` | no |
 | <a name="input_sidecar_dns_overwrite"></a> [sidecar\_dns\_overwrite](#input\_sidecar\_dns\_overwrite) | (Optional) Update an existing DNS name informed in 'sidecar\_dns\_name' variable | `bool` | `false` | no |
@@ -140,7 +149,6 @@ No modules.
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets to add sidecar to (list of string) | `list(string)` | n/a | yes |
 | <a name="input_sumologic_host"></a> [sumologic\_host](#input\_sumologic\_host) | Sumologic host | `string` | `""` | no |
 | <a name="input_sumologic_uri"></a> [sumologic\_uri](#input\_sumologic\_uri) | Sumologic uri | `string` | `""` | no |
-| <a name="input_reduce_security_group_rules_count"></a> [reduce\_security\_group\_rules\_count](#input\_reduce\_security\_group\_rules\_count) | If set to `false`, each port in `sidecar_ports` will be used individually for each CIDR in `db_inbound_cidr` to create inbound rules in the sidecar security group, resulting in a number of inbound rules that is equal to the number of `sidecar_ports` * `db_inbound_cidr`. If set to `true`, the entire sidecar port range from `min(sidecar_ports)` to `max(sidecar_ports)` will be used to configure each inbound rule for each CIDR in `db_inbound_cidr` for the sidecar security group. Setting it to `true` can be useful if you need to use multiple sequential sidecar ports and different CIDRs for DB inbound (`db_inbound_cidr`) since it will significantly reduce the number of inbound rules and avoid hitting AWS quotas. As a side effect, it will open all the ports between `min(sidecar_ports)` and `max(sidecar_ports)` in the security group created by this module. | `bool` | `false` | no |
 | <a name="input_volume_size"></a> [volume\_size](#input\_volume\_size) | Size of the sidecar disk | `number` | `15` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | AWS VPC ID to deploy sidecar to | `string` | n/a | yes |
 
@@ -150,5 +158,7 @@ No modules.
 |------|-------------|
 | <a name="output_aws_iam_role_arn"></a> [aws\_iam\_role\_arn](#output\_aws\_iam\_role\_arn) | Sidecar IAM role ARN |
 | <a name="output_aws_security_group_id"></a> [aws\_security\_group\_id](#output\_aws\_security\_group\_id) | Sidecar security group id |
+| <a name="output_sidecar_certificate_casigned_role_arn"></a> [sidecar\_certificate\_casigned\_role\_arn](#output\_sidecar\_certificate\_casigned\_role\_arn) | IAM role ARN to use in the Sidecar Certificate CA-signed module |
+| <a name="output_sidecar_certificate_casigned_secret_arn"></a> [sidecar\_certificate\_casigned\_secret\_arn](#output\_sidecar\_certificate\_casigned\_secret\_arn) | Secret ARN to use in the Sidecar Certificate CA-signed module |
 | <a name="output_sidecar_dns"></a> [sidecar\_dns](#output\_sidecar\_dns) | Sidecar DNS endpoint |
 | <a name="output_sidecar_load_balancer_dns"></a> [sidecar\_load\_balancer\_dns](#output\_sidecar\_load\_balancer\_dns) | Sidecar load balancer DNS endpoint |

--- a/cloudwatch_resources.tf
+++ b/cloudwatch_resources.tf
@@ -1,4 +1,4 @@
 resource "aws_cloudwatch_log_group" "cyral-sidecar-lg" {
-  name  = var.name_prefix
+  name              = var.name_prefix
   retention_in_days = var.cloudwatch_logs_retention
 }

--- a/ec2_locals.tf
+++ b/ec2_locals.tf
@@ -5,10 +5,10 @@ locals {
   sidecar_endpoint = (length(aws_route53_record.cyral-sidecar-dns-record) == 0 && length(var.sidecar_dns_name) > 0) ? (
     var.sidecar_dns_name
     ) : (
-      length(aws_route53_record.cyral-sidecar-dns-record) == 1 ? aws_route53_record.cyral-sidecar-dns-record[0].fqdn : aws_lb.cyral-lb.dns_name
-    )
+    length(aws_route53_record.cyral-sidecar-dns-record) == 1 ? aws_route53_record.cyral-sidecar-dns-record[0].fqdn : aws_lb.cyral-lb.dns_name
+  )
   protocol = var.external_tls_type == "no-tls" ? "http" : "https"
-  curl = var.external_tls_type == "tls-skip-verify" ? "curl -k" : "curl"
+  curl     = var.external_tls_type == "tls-skip-verify" ? "curl -k" : "curl"
 
   templatevars = {
     sidecar_id                    = var.sidecar_id

--- a/ec2_resources.tf
+++ b/ec2_resources.tf
@@ -12,15 +12,15 @@ data "aws_ami" "amazon_linux_2" {
 resource "aws_launch_configuration" "cyral-sidecar-lc" {
   # Launch configuration for sidecar instances that will run containers
   name_prefix                 = "${var.name_prefix}-autoscaling-"
-  image_id                    = var.ami_id != "" ? var.ami_id: data.aws_ami.amazon_linux_2.id
+  image_id                    = var.ami_id != "" ? var.ami_id : data.aws_ami.amazon_linux_2.id
   instance_type               = var.instance_type
   iam_instance_profile        = aws_iam_instance_profile.sidecar_profile.name
   key_name                    = var.key_name
   associate_public_ip_address = var.associate_public_ip_address
-  security_groups             = concat(
-                                  [aws_security_group.instance.id],
-                                  var.additional_security_groups
-                                )
+  security_groups = concat(
+    [aws_security_group.instance.id],
+    var.additional_security_groups
+  )
   metadata_options {
     # So docker can access ec2 metadata
     # see https://github.com/aws/aws-sdk-go/issues/2972
@@ -155,15 +155,15 @@ resource "aws_security_group" "instance" {
 
 resource "aws_lb" "cyral-lb" {
   # Core load balancer
-  name               = "${var.name_prefix}-lb"
-  internal           = var.load_balancer_scheme == "internet-facing" ? false : true
-  load_balancer_type = "network"
-  subnets            = length(var.load_balancer_subnets) > 0 ? var.load_balancer_subnets : var.subnets
+  name                             = "${var.name_prefix}-lb"
+  internal                         = var.load_balancer_scheme == "internet-facing" ? false : true
+  load_balancer_type               = "network"
+  subnets                          = length(var.load_balancer_subnets) > 0 ? var.load_balancer_subnets : var.subnets
   enable_cross_zone_load_balancing = var.enable_cross_zone_load_balancing
 }
 
 resource "aws_lb_target_group" "cyral-sidecar-tg" {
-  for_each = {for port in var.sidecar_ports: tostring(port) => port}
+  for_each = { for port in var.sidecar_ports : tostring(port) => port }
   name     = "${var.name_prefix}-tg${each.value}"
   port     = each.value
   protocol = "TCP"
@@ -176,13 +176,13 @@ resource "aws_lb_target_group" "cyral-sidecar-tg" {
 
 resource "aws_lb_listener" "cyral-sidecar-lb-ls" {
   # Listener for load balancer - all existing sidecar ports
-  for_each = {for port in var.sidecar_ports: tostring(port) => port}
+  for_each          = { for port in var.sidecar_ports : tostring(port) => port }
   load_balancer_arn = aws_lb.cyral-lb.arn
   port              = each.value
 
   # Snowflake listeners use TLS and the provided certificate
-  protocol          = contains(var.load_balancer_tls_ports, tonumber(each.value)) ? "TLS" : "TCP"
-  certificate_arn   = contains(var.load_balancer_tls_ports, tonumber(each.value)) ? var.load_balancer_certificate_arn : null
+  protocol        = contains(var.load_balancer_tls_ports, tonumber(each.value)) ? "TLS" : "TCP"
+  certificate_arn = contains(var.load_balancer_tls_ports, tonumber(each.value)) ? var.load_balancer_certificate_arn : null
 
   default_action {
     type             = "forward"

--- a/iam_resources.tf
+++ b/iam_resources.tf
@@ -1,3 +1,7 @@
+locals {
+  create_casigned_role = var.sidecar_certficate_casigned_account_id != ""
+}
+
 # Gets the ARN from a resource that is deployed by this module in order to
 # get the proper partition, region and account number for the aws account
 # where the resources are actually deployed. This prevents issues with
@@ -78,4 +82,50 @@ resource "aws_iam_role_policy_attachment" "user_policies" {
   for_each   = toset(var.iam_policies)
   role       = aws_iam_role.sidecar_role.name
   policy_arn = each.value
+}
+
+################################
+# Sidecar certificate CA-signed
+################################
+
+data "aws_iam_policy_document" "casigned_certificate_assume_role" {
+  count = local.create_casigned_role ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "AWS"
+      identifiers = [var.sidecar_certficate_casigned_account_id]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "casigned_certificate_secrets_manager" {
+  count = local.create_casigned_role ? 1 : 0
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:UpdateSecret"
+    ]
+    resources = [aws_secretsmanager_secret.casigned_certificate[0].id]
+  }
+}
+
+resource "aws_iam_role" "casigned_certificate" {
+  count              = local.create_casigned_role ? 1 : 0
+  name               = "${var.name_prefix}-casigned_certificate_lambda_role"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.casigned_certificate_assume_role[0].json
+}
+
+resource "aws_iam_policy" "casigned_certificate_secrets_manager" {
+  count  = local.create_casigned_role ? 1 : 0
+  name   = "${var.name_prefix}-casigned_certificate_secrets_manager"
+  path   = "/"
+  policy = data.aws_iam_policy_document.casigned_certificate_secrets_manager[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "casigned_certificate" {
+  count      = local.create_casigned_role ? 1 : 0
+  role       = aws_iam_role.casigned_certificate[0].name
+  policy_arn = aws_iam_policy.casigned_certificate_secrets_manager[0].arn
 }

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,8 @@
+locals {
+  output_certificate_casigned_secret_arn = var.sidecar_certficate_casigned_account_id != ""
+  output_certificate_casigned_role_arn   = local.output_certificate_casigned_secret_arn
+}
+
 output "sidecar_dns" {
   value       = local.sidecar_endpoint
   description = "Sidecar DNS endpoint"
@@ -9,11 +14,29 @@ output "sidecar_load_balancer_dns" {
 }
 
 output "aws_iam_role_arn" {
-	value = aws_iam_role.sidecar_role.arn
-	description = "Sidecar IAM role ARN"
+  value       = aws_iam_role.sidecar_role.arn
+  description = "Sidecar IAM role ARN"
 }
 
 output "aws_security_group_id" {
-	value = aws_security_group.instance.id
-	description = "Sidecar security group id"
+  value       = aws_security_group.instance.id
+  description = "Sidecar security group id"
+}
+
+output "sidecar_certificate_casigned_secret_arn" {
+  value = local.output_certificate_casigned_secret_arn ? (
+    aws_secretsmanager_secret.casigned_certificate[0].id
+    ) : (
+    null
+  )
+  description = "Secret ARN to use in the Sidecar Certificate CA-signed module"
+}
+
+output "sidecar_certificate_casigned_role_arn" {
+  value = local.output_certificate_casigned_role_arn ? (
+    aws_iam_role.casigned_certificate[0].arn
+    ) : (
+    null
+  )
+  description = "IAM role ARN to use in the Sidecar Certificate CA-signed module"
 }

--- a/route53_resources.tf
+++ b/route53_resources.tf
@@ -1,9 +1,9 @@
 resource "aws_route53_record" "cyral-sidecar-dns-record" {
-  count   = var.sidecar_dns_hosted_zone_id != "" && var.sidecar_dns_name != "" ? 1 : 0
-  zone_id = var.sidecar_dns_hosted_zone_id
-  name    = var.sidecar_dns_name
-  type    = "CNAME"
-  ttl     = "300"
-  records = [aws_lb.cyral-lb.dns_name]
+  count           = var.sidecar_dns_hosted_zone_id != "" && var.sidecar_dns_name != "" ? 1 : 0
+  zone_id         = var.sidecar_dns_hosted_zone_id
+  name            = var.sidecar_dns_name
+  type            = "CNAME"
+  ttl             = "300"
+  records         = [aws_lb.cyral-lb.dns_name]
   allow_overwrite = var.sidecar_dns_overwrite
 }

--- a/secretsmanager_resources.tf
+++ b/secretsmanager_resources.tf
@@ -4,11 +4,12 @@ locals {
     clientSecret         = var.client_secret
     containerRegistryKey = var.container_registry_key
   }
+  create_casigned_certificate_secret = var.sidecar_certficate_casigned_account_id != ""
 }
 
 resource "aws_secretsmanager_secret" "cyral-sidecar-secret" {
-  count = var.deploy_secrets ? 1 : 0
-  name  = var.secrets_location
+  count                   = var.deploy_secrets ? 1 : 0
+  name                    = var.secrets_location
   recovery_window_in_days = 0
 }
 
@@ -16,4 +17,17 @@ resource "aws_secretsmanager_secret_version" "cyral-sidecar-secret-version" {
   count         = var.deploy_secrets ? 1 : 0
   secret_id     = aws_secretsmanager_secret.cyral-sidecar-secret[0].id
   secret_string = jsonencode(local.sidecar_secrets)
+}
+
+resource "aws_secretsmanager_secret" "self_signed_certificate" {
+  name                    = "/cyral/sidecars/${var.sidecar_id}/self-signed-certificate"
+  description             = "Self-signed TLS certificate used by sidecar in case CA-signed is not found."
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret" "casigned_certificate" {
+  count                   = local.create_casigned_certificate_secret ? 1 : 0
+  name                    = "/cyral/sidecars/certificate/${var.name_prefix}"
+  description             = "CA-Signed TLS certificate used by Cyral sidecar. This secret is controlled by the Sidecar Certificate CA-signed Lambda."
+  recovery_window_in_days = 0
 }

--- a/variables_aws.tf
+++ b/variables_aws.tf
@@ -111,8 +111,8 @@ variable "db_inbound_cidr" {
 
 variable "reduce_security_group_rules_count" {
   description = "If set to `false`, each port in `sidecar_ports` will be used individually for each CIDR in `db_inbound_cidr` to create inbound rules in the sidecar security group, resulting in a number of inbound rules that is equal to the number of `sidecar_ports` * `db_inbound_cidr`. If set to `true`, the entire sidecar port range from `min(sidecar_ports)` to `max(sidecar_ports)` will be used to configure each inbound rule for each CIDR in `db_inbound_cidr` for the sidecar security group. Setting it to `true` can be useful if you need to use multiple sequential sidecar ports and different CIDRs for DB inbound (`db_inbound_cidr`) since it will significantly reduce the number of inbound rules and avoid hitting AWS quotas. As a side effect, it will open all the ports between `min(sidecar_ports)` and `max(sidecar_ports)` in the security group created by this module."
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "db_inbound_security_group" {
@@ -159,8 +159,8 @@ variable "cloudwatch_logs_retention" {
   description = "Cloudwatch logs retention in days"
   type        = number
   default     = 14
-#  validation {
-#    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653], var.cloudwatch_logs_retention)
-#    error_message = "Valid values are: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]."
-#  }
+  #  validation {
+  #    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653], var.cloudwatch_logs_retention)
+  #    error_message = "Valid values are: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]."
+  #  }
 }

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -94,6 +94,12 @@ variable "sidecar_id" {
   type        = string
 }
 
+variable "sidecar_certficate_casigned_account_id" {
+  description = "(Optional) AWS Account ID where the certificate CA-signed stack will be deployed."
+  type        = string
+  default     = ""
+}
+
 ##########################################################################################################
 # Sidecar endpoint possibilities:
 #

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       version = ">= 3.22.0"
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
     }
   }
 }


### PR DESCRIPTION
Add support for cross-account deployments, for the sidecar ca-signed certificate feature.

The scenario is the following: application in account B needs to manage a ca-signed certificate for account A.

This PR enables the above by creating a role and secret resources in account A, where the role gives permission for account B to edit the secret. You must input the AWS account id for account B in the variable `sidecar_certificate_casigned_account_id` for this to happen. If `sidecar_certificate_casigned_account_id` is empty, none of these resources (secret and role) will be created.

#### Testing
Manual cross-account deployment in AWS, verify that secret is created, and is able to be accessed by the ca-signed certificate feature.

#### Notes
Please note that `terraform fmt` has been run, hence the many edited files.