### PR TITLE
ENG-8959: Fix race condition when upgrading sidecar

### DIFF
--- a/iam_resources.tf
+++ b/iam_resources.tf
@@ -162,7 +162,7 @@ resource "aws_iam_role" "sidecar_created_certificate_lambda_execution" {
 
 resource "aws_iam_role_policy" "sidecar_created_certificate_lambda_execution" {
   name   = "${var.name_prefix}-sidecar_created_certificate_lambda"
-  role   = aws_iam_role.sidecar_created_certificate_lambda_execution
+  role   = aws_iam_role.sidecar_created_certificate_lambda_execution.id
   policy = data.aws_iam_policy_document.sidecar_created_certificate_lambda_execution.json
 }
 

--- a/iam_resources.tf
+++ b/iam_resources.tf
@@ -160,10 +160,15 @@ resource "aws_iam_role" "sidecar_created_certificate_lambda_execution" {
   assume_role_policy = data.aws_iam_policy_document.sidecar_created_certificate_lambda_assume_role.json
 }
 
-resource "aws_iam_role_policy" "sidecar_created_certificate_lambda_execution" {
+resource "aws_iam_policy" "sidecar_created_certificate_lambda_execution" {
   name   = "${var.name_prefix}-sidecar_created_certificate_lambda"
-  role   = aws_iam_role.sidecar_created_certificate_lambda_execution.id
+  path   = "/"
   policy = data.aws_iam_policy_document.sidecar_created_certificate_lambda_execution.json
+}
+
+resource "aws_iam_role_policy_attachment" "sidecar_created_certificate_lambda_execution" {
+  role       = aws_iam_role.sidecar_created_certificate_lambda_execution.name
+  policy_arn = aws_iam_policy.sidecar_created_certificate_lambda_execution.arn
 }
 
 #############################

--- a/iam_resources.tf
+++ b/iam_resources.tf
@@ -160,15 +160,10 @@ resource "aws_iam_role" "sidecar_created_certificate_lambda_execution" {
   assume_role_policy = data.aws_iam_policy_document.sidecar_created_certificate_lambda_assume_role.json
 }
 
-resource "aws_iam_policy" "sidecar_created_certificate_lambda_execution" {
+resource "aws_iam_role_policy" "sidecar_created_certificate_lambda_execution" {
   name   = "${var.name_prefix}-sidecar_created_certificate_lambda"
-  path   = "/"
+  role   = aws_iam_role.sidecar_created_certificate_lambda_execution
   policy = data.aws_iam_policy_document.sidecar_created_certificate_lambda_execution.json
-}
-
-resource "aws_iam_role_policy_attachment" "sidecar_created_certificate_lambda_execution" {
-  role       = aws_iam_role.sidecar_created_certificate_lambda_execution.name
-  policy_arn = aws_iam_policy.sidecar_created_certificate_lambda_execution.arn
 }
 
 #############################

--- a/lambda_resources.tf
+++ b/lambda_resources.tf
@@ -8,9 +8,6 @@ locals {
 }
 
 resource "aws_lambda_function" "sidecar_created_certificate" {
-  depends_on = [
-    aws_iam_role_policy_attachment.sidecar_created_certificate_lambda_execution
-  ]
   function_name = "${var.name_prefix}-sidecar_created_certificate"
   role          = aws_iam_role.sidecar_created_certificate_lambda_execution.arn
   runtime       = "go1.x"
@@ -30,6 +27,10 @@ resource "aws_lambda_function" "sidecar_created_certificate" {
       )
     }
   }
+
+  depends_on = [
+    aws_iam_role_policy.sidecar_created_certificate_lambda_execution
+  ]
 }
 
 resource "aws_lambda_invocation" "sidecar_created_certificate" {

--- a/lambda_resources.tf
+++ b/lambda_resources.tf
@@ -38,4 +38,7 @@ resource "aws_lambda_function" "sidecar_created_certificate" {
 resource "aws_lambda_invocation" "sidecar_created_certificate" {
   function_name = aws_lambda_function.sidecar_created_certificate.function_name
   input         = jsonencode({})
+  depends_on = [
+    aws_iam_role_policy.sidecar_created_certificate_lambda_execution
+  ]
 }

--- a/lambda_resources.tf
+++ b/lambda_resources.tf
@@ -27,22 +27,12 @@ resource "aws_lambda_function" "sidecar_created_certificate" {
       )
     }
   }
-
-  # Need permissions by inner policy to be created before lambda invocation can
-  # execute.
-  depends_on = [
-    aws_iam_role_policy.sidecar_created_certificate_lambda_execution
-  ]
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_lambda_invocation" "sidecar_created_certificate" {
   function_name = aws_lambda_function.sidecar_created_certificate.function_name
   input         = jsonencode({})
-  depends_on = [
-    aws_iam_role_policy.sidecar_created_certificate_lambda_execution
-  ]
+  lifecycle {
+    ignore_changes = [function_name]
+  }
 }

--- a/lambda_resources.tf
+++ b/lambda_resources.tf
@@ -33,6 +33,10 @@ resource "aws_lambda_function" "sidecar_created_certificate" {
   depends_on = [
     aws_iam_role_policy.sidecar_created_certificate_lambda_execution
   ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_lambda_invocation" "sidecar_created_certificate" {

--- a/lambda_resources.tf
+++ b/lambda_resources.tf
@@ -27,14 +27,15 @@ resource "aws_lambda_function" "sidecar_created_certificate" {
       )
     }
   }
+
+  # Need permissions by inner policy to be created before lambda invocation can
+  # execute.
+  depends_on = [
+    aws_iam_role_policy.sidecar_created_certificate_lambda_execution
+  ]
 }
 
 resource "aws_lambda_invocation" "sidecar_created_certificate" {
   function_name = aws_lambda_function.sidecar_created_certificate.function_name
   input         = jsonencode({})
-
-  # Need permissions by inner policy to be created before executing.
-  depends_on = [
-    aws_iam_role_policy.sidecar_created_certificate_lambda_execution
-  ]
 }

--- a/lambda_resources.tf
+++ b/lambda_resources.tf
@@ -30,6 +30,9 @@ resource "aws_lambda_function" "sidecar_created_certificate" {
 }
 
 resource "aws_lambda_invocation" "sidecar_created_certificate" {
+  depends_on = [
+    aws_iam_role_policy_attachment.sidecar_created_certificate_lambda_execution
+  ]
   function_name = aws_lambda_function.sidecar_created_certificate.function_name
   input         = jsonencode({})
 }

--- a/lambda_resources.tf
+++ b/lambda_resources.tf
@@ -8,6 +8,9 @@ locals {
 }
 
 resource "aws_lambda_function" "sidecar_created_certificate" {
+  depends_on = [
+    aws_iam_role_policy_attachment.sidecar_created_certificate_lambda_execution
+  ]
   function_name = "${var.name_prefix}-sidecar_created_certificate"
   role          = aws_iam_role.sidecar_created_certificate_lambda_execution.arn
   runtime       = "go1.x"
@@ -30,9 +33,6 @@ resource "aws_lambda_function" "sidecar_created_certificate" {
 }
 
 resource "aws_lambda_invocation" "sidecar_created_certificate" {
-  depends_on = [
-    aws_iam_role_policy_attachment.sidecar_created_certificate_lambda_execution
-  ]
   function_name = aws_lambda_function.sidecar_created_certificate.function_name
   input         = jsonencode({})
 }

--- a/lambda_resources.tf
+++ b/lambda_resources.tf
@@ -27,13 +27,14 @@ resource "aws_lambda_function" "sidecar_created_certificate" {
       )
     }
   }
-
-  depends_on = [
-    aws_iam_role_policy.sidecar_created_certificate_lambda_execution
-  ]
 }
 
 resource "aws_lambda_invocation" "sidecar_created_certificate" {
   function_name = aws_lambda_function.sidecar_created_certificate.function_name
   input         = jsonencode({})
+
+  # Need permissions by inner policy to be created before executing.
+  depends_on = [
+    aws_iam_role_policy.sidecar_created_certificate_lambda_execution
+  ]
 }


### PR DESCRIPTION
This PR fixes an issue when upgrading sidecar from versions previous to #39 to versions after #39.

Specifically, if `name_prefix` is modified, and the module is upgraded (i.e. `terraform init -upgrade`), when the user runs `terraform apply`, the resource `aws_lambda_invocation.sidecar_created_certificate` was failing to be created, because the lambda function IAM policy was not in place when it tried to access the sidecar-created certificate secret.

To solve this, `depends_on` did not work. I am not sure why. I tried every combination I could imagine. The only thing that worked was the `lifecycle` meta-argument `ignore_changes`. Please see PR modifications for details. This is OK because with the sidecar-created certificate, we don't need to trigger the lambda function again if the lambda function is recreated. The sidecar-created certificate is self-signed, and thus can be used for a long time with no need of replacement.