### PR TITLE
Fix minimum AWS provider requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ Check the [upgrade notes](docs/upgrade-notes.md) section if you are upgrading an
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.22.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.73.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.22.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.73.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12"
   required_providers {
     aws = {
-      version = ">= 3.22.0"
+      version = ">= 3.73.0"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
Resource `aws_lambda_invocation` included recently requires a minimum AWS provider version of `3.73.0`.