### PR TITLE
ENG-9286: Deprecate public docker route

### DIFF
--- a/ec2_locals.tf
+++ b/ec2_locals.tf
@@ -14,6 +14,7 @@ locals {
     sidecar_id                            = var.sidecar_id
     name_prefix                           = var.name_prefix
     controlplane_host                     = var.control_plane
+    controlplane_port                     = var.control_plane_port
     container_registry                    = var.container_registry
     container_registry_username           = var.container_registry_username
     elk_address                           = var.elk_address
@@ -41,6 +42,10 @@ locals {
     mysql_multiplexed_port                = var.mysql_multiplexed_port
     sidecar_created_certificate_secret_id = aws_secretsmanager_secret.sidecar_created_certificate.arn
     load_balancer_tls_ports               = join(",", var.load_balancer_tls_ports)
+    protocol                              = local.protocol
+    curl                                  = local.curl
+    sidecar_version                       = var.sidecar_version
+    repositories_supported                = join(",", var.repositories_supported)
   }
 
   cloud_init_pre  = templatefile("${path.module}/files/cloud-init-pre.sh.tmpl", local.templatevars)

--- a/ec2_locals.tf
+++ b/ec2_locals.tf
@@ -14,7 +14,6 @@ locals {
     sidecar_id                            = var.sidecar_id
     name_prefix                           = var.name_prefix
     controlplane_host                     = var.control_plane
-    controlplane_port                     = var.control_plane_port
     container_registry                    = var.container_registry
     container_registry_username           = var.container_registry_username
     elk_address                           = var.elk_address

--- a/ec2_resources.tf
+++ b/ec2_resources.tf
@@ -41,9 +41,16 @@ resource "aws_launch_configuration" "cyral-sidecar-lc" {
 
   echo "Downloading sidecar.compose.yaml..."
   function download_sidecar () {
-    local url="${local.protocol}://${var.control_plane}/deploy/sidecar.compose.yaml?TemplateVersion=${var.sidecar_version}&TemplateType=terraform&LogIntegration=${var.log_integration}&MetricsIntegration=${var.metrics_integration}&HCVaultIntegrationID=${var.hc_vault_integration_id}&WiresEnabled=${join(",", var.repositories_supported)}"
+    local url_token="${local.protocol}://${var.control_plane}:${var.external_http_port}/v1/users/oidc/token"
+    local token=$(${local.curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="${var.client_id}" -d client_secret="${var.client_secret}" 2>&1)
+    local token_error=$(echo $?)
+    if [[ $token_error -ne 0 ]]; then
+      return 1
+    fi
+    local access_token=$(echo "$token" | jq -r .access_token)
+    local url="${local.protocol}://${var.control_plane}/deploy/docker-compose?TemplateVersion=${var.sidecar_version}&TemplateType=terraform&LogIntegration=${var.log_integration}&MetricsIntegration=${var.metrics_integration}&HCVaultIntegrationID=${var.hc_vault_integration_id}&WiresEnabled=${join(",", var.repositories_supported)}"
     echo "Trying to download the sidecar template from: $url"
-    if [[ $(${local.curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url") = 200 ]]; then
+    if [[ $(${local.curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url" -H "authorization: Bearer $access_token") = 200 ]]; then
       return 0
     fi
     return 1

--- a/ec2_resources.tf
+++ b/ec2_resources.tf
@@ -41,7 +41,7 @@ resource "aws_launch_configuration" "cyral-sidecar-lc" {
 
   echo "Downloading sidecar.compose.yaml..."
   function download_sidecar () {
-    local url_token="${local.protocol}://${var.control_plane}:${var.external_http_port}/v1/users/oidc/token"
+    local url_token="${local.protocol}://${var.control_plane}:${var.control_plane_port}/v1/users/oidc/token"
     local token=$(${local.curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="${var.client_id}" -d client_secret="${var.client_secret}" 2>&1)
     local token_error=$(echo $?)
     if [[ $token_error -ne 0 ]]; then

--- a/ec2_resources.tf
+++ b/ec2_resources.tf
@@ -48,7 +48,7 @@ resource "aws_launch_configuration" "cyral-sidecar-lc" {
       return 1
     fi
     local access_token=$(echo "$token" | jq -r .access_token)
-    local url="${local.protocol}://${var.control_plane}/deploy/docker-compose?TemplateVersion=${var.sidecar_version}&TemplateType=terraform&LogIntegration=${var.log_integration}&MetricsIntegration=${var.metrics_integration}&HCVaultIntegrationID=${var.hc_vault_integration_id}&WiresEnabled=${join(",", var.repositories_supported)}"
+    local url="${local.protocol}://${var.control_plane}/deploy/docker-compose?TemplateVersion=${var.sidecar_version}&clientId=${var.client_id}&clientSecret=${var.client_secret}&SidecarId=${var.sidecar_id}&TemplateType=terraform&LogIntegration=${var.log_integration}&MetricsIntegration=${var.metrics_integration}&HCVaultIntegrationID=${var.hc_vault_integration_id}&WiresEnabled=${join(",", var.repositories_supported)}"
     echo "Trying to download the sidecar template from: $url"
     if [[ $(${local.curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url" -H "authorization: Bearer $access_token") = 200 ]]; then
       return 0

--- a/ec2_resources.tf
+++ b/ec2_resources.tf
@@ -41,7 +41,7 @@ resource "aws_launch_configuration" "cyral-sidecar-lc" {
 
   echo "Downloading sidecar.compose.yaml..."
   function download_sidecar () {
-    if [[ -z "${var.control_plane_port}" ]]; then
+    if [[ -z ${var.control_plane_port} ]]; then
       # No control_plane_port is set, testing default (443) and then 8000
       local url_token="${local.protocol}://${var.control_plane}/v1/users/oidc/token"
       local token=$(${local.curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="${var.client_id}" -d client_secret="${var.client_secret}" 2>&1)

--- a/files/cloud-init-post.sh.tmpl
+++ b/files/cloud-init-post.sh.tmpl
@@ -1,4 +1,60 @@
-function login () {
+  echo "Fetching secret: sidecar client ID and client secret."
+  SIDECAR_CLIENT_ID=$(aws secretsmanager get-secret-value --secret-id ${secrets_location} --query SecretString --output text \
+    --region ${aws_region} | jq -r .clientId)
+  SIDECAR_CLIENT_SECRET=$(aws secretsmanager get-secret-value --secret-id ${secrets_location} --query SecretString --output text \
+    --region ${aws_region} | jq -r .clientSecret)
+
+  echo "Downloading sidecar.compose.yaml..."
+  function download_sidecar () {
+    if [[ -z ${controlplane_port} ]]; then
+      # No controlplane_port is set, testing default (443) and then 8000
+      local url_token="${protocol}://${controlplane_host}/v1/users/oidc/token"
+      local token=$(${local.curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="${SIDECAR_CLIENT_ID}" -d client_secret="${SIDECAR_CLIENT_SECRET}" 2>&1)
+      local token_error=$(echo $?)
+      if [[ $token_error -ne 0 ]]; then
+        local url_token="${protocol}://${controlplane_host}:8000/v1/users/oidc/token"
+        local token=$(${local.curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="${SIDECAR_CLIENT_ID}" -d client_secret="${SIDECAR_CLIENT_SECRET}" 2>&1)
+        local token_error=$(echo $?)
+        if [[ $token_error -ne 0 ]]; then
+          return 1
+        fi
+      fi
+    else
+      # Use the controlplane_port defined
+      local url_token="${protocol}://${controlplane_host}:${controlplane_port}/v1/users/oidc/token"
+      local token=$(${local.curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="${SIDECAR_CLIENT_ID}" -d client_secret="${SIDECAR_CLIENT_SECRET}" 2>&1)
+      local token_error=$(echo $?)
+      if [[ $token_error -ne 0 ]]; then
+        return 1
+      fi
+    fi
+    local access_token=$(echo "$token" | jq -r .access_token)
+    local url="${protocol}://${controlplane_host}/deploy/docker-compose?TemplateVersion=${sidecar_version}&clientId=${SIDECAR_CLIENT_ID}&clientSecret=${SIDECAR_CLIENT_SECRET}&SidecarId=${sidecar_id}&TemplateType=terraform&LogIntegration=${log_integration}&MetricsIntegration=${metrics_integration}&HCVaultIntegrationID=${hc_vault_integration_id}&WiresEnabled=${repositories_supported}"
+    echo "Trying to download the sidecar template from: $url"
+    if [[ $(${local.curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url" -H "authorization: Bearer $access_token") = 200 ]]; then
+      return 0
+    fi
+    return 1
+  }
+  retry download_sidecar
+
+  echo "Fetching secret: container registry key..."
+  aws secretsmanager get-secret-value --secret-id ${secrets_location} --query SecretString --output text \
+    --region ${aws_region} | jq -r 'select(.containerRegistryKey != null) | .containerRegistryKey' | base64 --decode > /home/ec2-user/cyral/container_registry_key.json
+  until [ -f /home/ec2-user/cyral/container_registry_key.json ]; do echo "wait"; sleep 1; done
+  cat >> /home/ec2-user/.bash_profile << EOF
+  if [[ ${container_registry} == *".amazonaws.com"* ]]; then
+    echo "Logging in to AWS ECR..."
+    eval $(aws ecr --no-include-email get-login  --region ${aws_region})
+  elif [ -s /home/ec2-user/cyral/container_registry_key.json ]; then
+      echo "Logging in to GCR..."
+      cat /home/ec2-user/cyral/container_registry_key.json | docker login -u ${container_registry_username} --password-stdin https://gcr.io
+  else
+      echo "Won't log in automatically to any image registry. Image registry set to: ${container_registry}"
+  fi
+  EOF
+
+  function login () {
   if [[ ${container_registry} == *".amazonaws.com"* ]]; then
     echo "(login): Logging in to AWS ECR..."
     eval $(aws ecr --no-include-email get-login  --region ${aws_region})

--- a/files/cloud-init-post.sh.tmpl
+++ b/files/cloud-init-post.sh.tmpl
@@ -5,33 +5,33 @@
     --region ${aws_region} | jq -r .clientSecret)
 
   echo "Downloading sidecar.compose.yaml..."
+  function get_token () {
+    local url_token="${local.protocol}://${var.control_plane}:$1/v1/users/oidc/token"
+    token=$(${local.curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="${var.client_id}" -d client_secret="${var.client_secret}" 2>&1)
+    token_error=$(echo $?)
+  }
+
   function download_sidecar () {
-    if [[ -z "${controlplane_port}" ]]; then
-      # No controlplane_port is set, testing default (443) and then 8000
-      local url_token="${protocol}://${controlplane_host}/v1/users/oidc/token"
-      local token=$(${curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="$${SIDECAR_CLIENT_ID}" -d client_secret="$${SIDECAR_CLIENT_SECRET}" 2>&1)
-      local token_error=$(echo $?)
+    if [[ -z ${var.control_plane_port} ]]; then
+      # No control_plane_port is set, testing default (443) and then 8000
+      get_token "443"
       if [[ $token_error -ne 0 ]]; then
-        local url_token="${protocol}://${controlplane_host}:8000/v1/users/oidc/token"
-        local token=$(${curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="$${SIDECAR_CLIENT_ID}" -d client_secret="$${SIDECAR_CLIENT_SECRET}" 2>&1)
-        local token_error=$(echo $?)
+        get_token "8000"
         if [[ $token_error -ne 0 ]]; then
           return 1
         fi
       fi
     else
-      # Use the controlplane_port defined
-      local url_token="${protocol}://${controlplane_host}:${controlplane_port}/v1/users/oidc/token"
-      local token=$(${curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="$${SIDECAR_CLIENT_ID}" -d client_secret="$${SIDECAR_CLIENT_SECRET}" 2>&1)
-      local token_error=$(echo $?)
+      # Use the control_plane_port defined
+      get_token ${var.control_plane_port}
       if [[ $token_error -ne 0 ]]; then
         return 1
       fi
     fi
     local access_token=$(echo "$token" | jq -r .access_token)
-    local url="${protocol}://${controlplane_host}/deploy/docker-compose?TemplateVersion=${sidecar_version}&TemplateType=terraform&LogIntegration=${log_integration}&MetricsIntegration=${metrics_integration}&HCVaultIntegrationID=${hc_vault_integration_id}&WiresEnabled=${repositories_supported}"
+    local url="${local.protocol}://${var.control_plane}/deploy/docker-compose?TemplateVersion=${var.sidecar_version}&clientId=${var.client_id}&clientSecret=${var.client_secret}&SidecarId=${var.sidecar_id}&TemplateType=terraform&LogIntegration=${var.log_integration}&MetricsIntegration=${var.metrics_integration}&HCVaultIntegrationID=${var.hc_vault_integration_id}&WiresEnabled=${join(",", var.repositories_supported)}"
     echo "Trying to download the sidecar template from: $url"
-    if [[ $(${curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url" -H "Authorization: Bearer $access_token") = 200 ]]; then
+    if [[ $(${local.curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url" -H "authorization: Bearer $access_token") = 200 ]]; then
       return 0
     fi
     return 1

--- a/files/cloud-init-post.sh.tmpl
+++ b/files/cloud-init-post.sh.tmpl
@@ -6,7 +6,7 @@
 
   echo "Downloading sidecar.compose.yaml..."
   function download_sidecar () {
-    if [[ -z ${controlplane_port} ]]; then
+    if [[ -z \"${controlplane_port}\" ]]; then
       # No controlplane_port is set, testing default (443) and then 8000
       local url_token="${protocol}://${controlplane_host}/v1/users/oidc/token"
       local token=$(${curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="$${SIDECAR_CLIENT_ID}" -d client_secret="$${SIDECAR_CLIENT_SECRET}" 2>&1)
@@ -37,6 +37,9 @@
     return 1
   }
   retry download_sidecar
+
+  unset SIDECAR_CLIENT_ID
+  unset SIDECAR_CLIENT_SECRET
 
   echo "Fetching secret: container registry key..."
   aws secretsmanager get-secret-value --secret-id ${secrets_location} --query SecretString --output text \

--- a/files/cloud-init-post.sh.tmpl
+++ b/files/cloud-init-post.sh.tmpl
@@ -6,7 +6,7 @@
 
   echo "Downloading sidecar.compose.yaml..."
   function download_sidecar () {
-    if [[ -z \"${controlplane_port}\" ]]; then
+    if [[ -z "${controlplane_port}" ]]; then
       # No controlplane_port is set, testing default (443) and then 8000
       local url_token="${protocol}://${controlplane_host}/v1/users/oidc/token"
       local token=$(${curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="$${SIDECAR_CLIENT_ID}" -d client_secret="$${SIDECAR_CLIENT_SECRET}" 2>&1)
@@ -29,9 +29,9 @@
       fi
     fi
     local access_token=$(echo "$token" | jq -r .access_token)
-    local url="${protocol}://${controlplane_host}/deploy/docker-compose?TemplateVersion=${sidecar_version}&clientId=$${SIDECAR_CLIENT_ID}&clientSecret=$${SIDECAR_CLIENT_SECRET}&SidecarId=${sidecar_id}&TemplateType=terraform&LogIntegration=${log_integration}&MetricsIntegration=${metrics_integration}&HCVaultIntegrationID=${hc_vault_integration_id}&WiresEnabled=${repositories_supported}"
+    local url="${protocol}://${controlplane_host}/deploy/docker-compose?TemplateVersion=${sidecar_version}&TemplateType=terraform&LogIntegration=${log_integration}&MetricsIntegration=${metrics_integration}&HCVaultIntegrationID=${hc_vault_integration_id}&WiresEnabled=${repositories_supported}"
     echo "Trying to download the sidecar template from: $url"
-    if [[ $(${curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url" -H "authorization: Bearer $access_token") = 200 ]]; then
+    if [[ $(${curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url" -H "Authorization: Bearer $access_token") = 200 ]]; then
       return 0
     fi
     return 1

--- a/files/cloud-init-post.sh.tmpl
+++ b/files/cloud-init-post.sh.tmpl
@@ -12,18 +12,10 @@ function get_token () {
 }
 
 function download_sidecar () {
-  if [[ -z "${controlplane_port}" ]]; then
-    # No control_plane_port is set, testing default (443) and then 8000
-    get_token "443"
-    if [[ $token_error -ne 0 ]]; then
-      get_token "8000"
-      if [[ $token_error -ne 0 ]]; then
-        return 1
-      fi
-    fi
-  else
-    # Use the control_plane_port defined
-    get_token ${controlplane_port}
+  # Test default (443) and then 8000
+  get_token "443"
+  if [[ $token_error -ne 0 ]]; then
+    get_token "8000"
     if [[ $token_error -ne 0 ]]; then
       return 1
     fi

--- a/files/cloud-init-post.sh.tmpl
+++ b/files/cloud-init-post.sh.tmpl
@@ -6,13 +6,13 @@
 
   echo "Downloading sidecar.compose.yaml..."
   function get_token () {
-    local url_token="${local.protocol}://${var.control_plane}:$1/v1/users/oidc/token"
-    token=$(${local.curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="${var.client_id}" -d client_secret="${var.client_secret}" 2>&1)
+    local url_token="${protocol}://${controlplane_host}:$1/v1/users/oidc/token"
+    token=$(${curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="${SIDECAR_CLIENT_ID}" -d client_secret="${SIDECAR_CLIENT_SECRET}" 2>&1)
     token_error=$(echo $?)
   }
 
   function download_sidecar () {
-    if [[ -z ${var.control_plane_port} ]]; then
+    if [[ -z "${controlplane_port}" ]]; then
       # No control_plane_port is set, testing default (443) and then 8000
       get_token "443"
       if [[ $token_error -ne 0 ]]; then
@@ -23,15 +23,15 @@
       fi
     else
       # Use the control_plane_port defined
-      get_token ${var.control_plane_port}
+      get_token ${controlplane_port}
       if [[ $token_error -ne 0 ]]; then
         return 1
       fi
     fi
     local access_token=$(echo "$token" | jq -r .access_token)
-    local url="${local.protocol}://${var.control_plane}/deploy/docker-compose?TemplateVersion=${var.sidecar_version}&clientId=${var.client_id}&clientSecret=${var.client_secret}&SidecarId=${var.sidecar_id}&TemplateType=terraform&LogIntegration=${var.log_integration}&MetricsIntegration=${var.metrics_integration}&HCVaultIntegrationID=${var.hc_vault_integration_id}&WiresEnabled=${join(",", var.repositories_supported)}"
+    local url="${protocol}://${controlplane_host}/deploy/docker-compose?TemplateVersion=${sidecar_version}&TemplateType=terraform&LogIntegration=${log_integration}&MetricsIntegration=${metrics_integration}&HCVaultIntegrationID=${hc_vault_integration_id}&WiresEnabled=${repositories_supported}"
     echo "Trying to download the sidecar template from: $url"
-    if [[ $(${local.curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url" -H "authorization: Bearer $access_token") = 200 ]]; then
+    if [[ $(${curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url" -H "Authorization: Bearer $access_token") = 200 ]]; then
       return 0
     fi
     return 1

--- a/files/cloud-init-post.sh.tmpl
+++ b/files/cloud-init-post.sh.tmpl
@@ -1,71 +1,60 @@
-  echo "Fetching secret: sidecar client ID and client secret."
-  SIDECAR_CLIENT_ID=$(aws secretsmanager get-secret-value --secret-id ${secrets_location} --query SecretString --output text \
+echo "Fetching secret: sidecar client ID and client secret."
+SIDECAR_CLIENT_ID=$(aws secretsmanager get-secret-value --secret-id ${secrets_location} --query SecretString --output text \
     --region ${aws_region} | jq -r .clientId)
-  SIDECAR_CLIENT_SECRET=$(aws secretsmanager get-secret-value --secret-id ${secrets_location} --query SecretString --output text \
+SIDECAR_CLIENT_SECRET=$(aws secretsmanager get-secret-value --secret-id ${secrets_location} --query SecretString --output text \
     --region ${aws_region} | jq -r .clientSecret)
 
-  echo "Downloading sidecar.compose.yaml..."
-  function get_token () {
-    local url_token="${protocol}://${controlplane_host}:$1/v1/users/oidc/token"
-    token=$(${curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="${SIDECAR_CLIENT_ID}" -d client_secret="${SIDECAR_CLIENT_SECRET}" 2>&1)
-    token_error=$(echo $?)
-  }
+echo "Downloading sidecar.compose.yaml..."
+function get_token () {
+  local url_token="${protocol}://${controlplane_host}:$1/v1/users/oidc/token"
+  token=$(${curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="$${SIDECAR_CLIENT_ID}" -d client_secret="$${SIDECAR_CLIENT_SECRET}" 2>&1)
+  token_error=$(echo $?)
+}
 
-  function download_sidecar () {
-    if [[ -z "${controlplane_port}" ]]; then
-      # No control_plane_port is set, testing default (443) and then 8000
-      get_token "443"
-      if [[ $token_error -ne 0 ]]; then
-        get_token "8000"
-        if [[ $token_error -ne 0 ]]; then
-          return 1
-        fi
-      fi
-    else
-      # Use the control_plane_port defined
-      get_token ${controlplane_port}
+function download_sidecar () {
+  if [[ -z "${controlplane_port}" ]]; then
+    # No control_plane_port is set, testing default (443) and then 8000
+    get_token "443"
+    if [[ $token_error -ne 0 ]]; then
+      get_token "8000"
       if [[ $token_error -ne 0 ]]; then
         return 1
       fi
     fi
-    local access_token=$(echo "$token" | jq -r .access_token)
-    local url="${protocol}://${controlplane_host}/deploy/docker-compose?TemplateVersion=${sidecar_version}&TemplateType=terraform&LogIntegration=${log_integration}&MetricsIntegration=${metrics_integration}&HCVaultIntegrationID=${hc_vault_integration_id}&WiresEnabled=${repositories_supported}"
-    echo "Trying to download the sidecar template from: $url"
-    if [[ $(${curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url" -H "Authorization: Bearer $access_token") = 200 ]]; then
-      return 0
-    fi
-    return 1
-  }
-  retry download_sidecar
-
-  unset SIDECAR_CLIENT_ID
-  unset SIDECAR_CLIENT_SECRET
-
-  echo "Fetching secret: container registry key..."
-  aws secretsmanager get-secret-value --secret-id ${secrets_location} --query SecretString --output text \
-    --region ${aws_region} | jq -r 'select(.containerRegistryKey != null) | .containerRegistryKey' | base64 --decode > /home/ec2-user/cyral/container_registry_key.json
-  until [ -f /home/ec2-user/cyral/container_registry_key.json ]; do echo "wait"; sleep 1; done
-  cat >> /home/ec2-user/.bash_profile << EOF
-  if [[ ${container_registry} == *".amazonaws.com"* ]]; then
-    echo "Logging in to AWS ECR..."
-    eval $(aws ecr --no-include-email get-login  --region ${aws_region})
-  elif [ -s /home/ec2-user/cyral/container_registry_key.json ]; then
-      echo "Logging in to GCR..."
-      cat /home/ec2-user/cyral/container_registry_key.json | docker login -u ${container_registry_username} --password-stdin https://gcr.io
   else
-      echo "Won't log in automatically to any image registry. Image registry set to: ${container_registry}"
+    # Use the control_plane_port defined
+    get_token ${controlplane_port}
+    if [[ $token_error -ne 0 ]]; then
+      return 1
+    fi
   fi
-  EOF
+  local access_token=$(echo "$token" | jq -r .access_token)
+  local url="${protocol}://${controlplane_host}/deploy/docker-compose?TemplateVersion=${sidecar_version}&TemplateType=terraform&LogIntegration=${log_integration}&MetricsIntegration=${metrics_integration}&HCVaultIntegrationID=${hc_vault_integration_id}&WiresEnabled=${repositories_supported}"
+  echo "Trying to download the sidecar template from: $url"
+  if [[ $(${curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url" -H "Authorization: Bearer $access_token") = 200 ]]; then
+    return 0
+  fi
+  return 1
+}
+retry download_sidecar
 
-  function login () {
+unset SIDECAR_CLIENT_ID
+unset SIDECAR_CLIENT_SECRET
+
+echo "Fetching secret: container registry key..."
+aws secretsmanager get-secret-value --secret-id ${secrets_location} --query SecretString --output text \
+    --region ${aws_region} | jq -r 'select(.containerRegistryKey != null) | .containerRegistryKey' | base64 --decode > /home/ec2-user/cyral/container_registry_key.json
+until [ -f /home/ec2-user/cyral/container_registry_key.json ]; do echo "wait"; sleep 1; done
+
+function login () {
   if [[ ${container_registry} == *".amazonaws.com"* ]]; then
     echo "(login): Logging in to AWS ECR..."
     eval $(aws ecr --no-include-email get-login  --region ${aws_region})
   elif [ -s /home/ec2-user/cyral/container_registry_key.json ]; then
-      echo "(login): Logging in to GCR..."
-      cat /home/ec2-user/cyral/container_registry_key.json | docker login -u ${container_registry_username} --password-stdin https://gcr.io
+    echo "(login): Logging in to GCR..."
+    cat /home/ec2-user/cyral/container_registry_key.json | docker login -u ${container_registry_username} --password-stdin https://gcr.io
   else
-      echo "(login): Won't log in automatically to any image registry. Image registry set to: ${container_registry}"
+    echo "(login): Won't log in automatically to any image registry. Image registry set to: ${container_registry}"
   fi
 }
 

--- a/files/cloud-init-post.sh.tmpl
+++ b/files/cloud-init-post.sh.tmpl
@@ -9,11 +9,11 @@
     if [[ -z ${controlplane_port} ]]; then
       # No controlplane_port is set, testing default (443) and then 8000
       local url_token="${protocol}://${controlplane_host}/v1/users/oidc/token"
-      local token=$(${local.curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="${SIDECAR_CLIENT_ID}" -d client_secret="${SIDECAR_CLIENT_SECRET}" 2>&1)
+      local token=$(${curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="$${SIDECAR_CLIENT_ID}" -d client_secret="$${SIDECAR_CLIENT_SECRET}" 2>&1)
       local token_error=$(echo $?)
       if [[ $token_error -ne 0 ]]; then
         local url_token="${protocol}://${controlplane_host}:8000/v1/users/oidc/token"
-        local token=$(${local.curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="${SIDECAR_CLIENT_ID}" -d client_secret="${SIDECAR_CLIENT_SECRET}" 2>&1)
+        local token=$(${curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="$${SIDECAR_CLIENT_ID}" -d client_secret="$${SIDECAR_CLIENT_SECRET}" 2>&1)
         local token_error=$(echo $?)
         if [[ $token_error -ne 0 ]]; then
           return 1
@@ -22,16 +22,16 @@
     else
       # Use the controlplane_port defined
       local url_token="${protocol}://${controlplane_host}:${controlplane_port}/v1/users/oidc/token"
-      local token=$(${local.curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="${SIDECAR_CLIENT_ID}" -d client_secret="${SIDECAR_CLIENT_SECRET}" 2>&1)
+      local token=$(${curl} --fail --no-progress-meter --request POST "$url_token" -d grant_type=client_credentials -d client_id="$${SIDECAR_CLIENT_ID}" -d client_secret="$${SIDECAR_CLIENT_SECRET}" 2>&1)
       local token_error=$(echo $?)
       if [[ $token_error -ne 0 ]]; then
         return 1
       fi
     fi
     local access_token=$(echo "$token" | jq -r .access_token)
-    local url="${protocol}://${controlplane_host}/deploy/docker-compose?TemplateVersion=${sidecar_version}&clientId=${SIDECAR_CLIENT_ID}&clientSecret=${SIDECAR_CLIENT_SECRET}&SidecarId=${sidecar_id}&TemplateType=terraform&LogIntegration=${log_integration}&MetricsIntegration=${metrics_integration}&HCVaultIntegrationID=${hc_vault_integration_id}&WiresEnabled=${repositories_supported}"
+    local url="${protocol}://${controlplane_host}/deploy/docker-compose?TemplateVersion=${sidecar_version}&clientId=$${SIDECAR_CLIENT_ID}&clientSecret=$${SIDECAR_CLIENT_SECRET}&SidecarId=${sidecar_id}&TemplateType=terraform&LogIntegration=${log_integration}&MetricsIntegration=${metrics_integration}&HCVaultIntegrationID=${hc_vault_integration_id}&WiresEnabled=${repositories_supported}"
     echo "Trying to download the sidecar template from: $url"
-    if [[ $(${local.curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url" -H "authorization: Bearer $access_token") = 200 ]]; then
+    if [[ $(${curl} -s -o /home/ec2-user/sidecar.compose.yaml -w "%%{http_code}" -L "$url" -H "authorization: Bearer $access_token") = 200 ]]; then
       return 0
     fi
     return 1

--- a/files/cloud-init-pre.sh.tmpl
+++ b/files/cloud-init-pre.sh.tmpl
@@ -115,7 +115,6 @@ echo "Initializing environment variables..."
 cat > /home/ec2-user/.env << EOF
 SIDECAR_ID=${sidecar_id}
 CONTROLPLANE_HOST=${controlplane_host}
-CONTROLPLANE_PORT=8020
 CONTAINER_REGISTRY=${container_registry}
 SECRETS_LOCATION=${secrets_location}
 ELK_ADDRESS=${elk_address}

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -34,8 +34,8 @@ variable "control_plane" {
   type        = string
 }
 
-variable "external_http_port" {
-  description = "external CP HTTP port"
+variable "control_plane_port" {
+  description = "TCP/IP port of the control plane."
   type        = string
   default     = "8000"
 }

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -34,12 +34,6 @@ variable "control_plane" {
   type        = string
 }
 
-variable "control_plane_port" {
-  description = "Control plane API port."
-  type        = string
-  default     = ""
-}
-
 variable "external_tls_type" {
   description = "TLS mode for the control plane - tls, tls-skip-verify, no-tls"
   type        = string

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -35,9 +35,9 @@ variable "control_plane" {
 }
 
 variable "control_plane_port" {
-  description = "TCP/IP port of the control plane."
+  description = "Control plane API port."
   type        = string
-  default     = "8000"
+  default     = ""
 }
 
 variable "external_tls_type" {

--- a/variables_sidecar.tf
+++ b/variables_sidecar.tf
@@ -34,6 +34,12 @@ variable "control_plane" {
   type        = string
 }
 
+variable "external_http_port" {
+  description = "external CP HTTP port"
+  type        = string
+  default     = "8000"
+}
+
 variable "external_tls_type" {
   description = "TLS mode for the control plane - tls, tls-skip-verify, no-tls"
   type        = string


### PR DESCRIPTION
Update POST route permission so we can use only the private route for the new CPs